### PR TITLE
[WIP]Prefetch internal links to speed navigation

### DIFF
--- a/public/js/gulliver.es6.js
+++ b/public/js/gulliver.es6.js
@@ -52,7 +52,8 @@ class Gulliver {
   constructor() {
     this.config = Config.from(document.querySelector('#config'));
     this.shell = new Shell(document);
-    this.router = new Router(window, document.querySelector('main'));
+    const routeContainer = document.querySelector('main');
+    this.router = new Router(window, routeContainer);
     this.offlineSupport = new OfflineSupport(window, this.router);
     this._setupRoutes();
     this.setupBacklink();
@@ -74,8 +75,11 @@ class Gulliver {
     this.router.addEventListener('navigate', e => {
       this.analytics.trackPageView(e.detail.url);
       this.shell.onRouteChange(e.detail.route);
+      this.offlineSupport.prefetchLinks(e.detail.route, e.detail.container);
       this.offlineSupport.markAsCached(document.querySelectorAll('.offline-aware'));
     });
+    const route = this.router.findRoute(document.location.href);
+    this.offlineSupport.prefetchLinks(route, routeContainer);
   }
 
   _addRoute(regexp, transitionStrategy, onRouteAttached, shellState) {

--- a/public/js/routing/router.js
+++ b/public/js/routing/router.js
@@ -88,7 +88,8 @@ export default class Router {
     const event = this._document.createEvent('CustomEvent');
     const detail = {
       url: url,
-      route: route
+      route: route,
+      container: this._container
     };
     event.initCustomEvent(
         'navigate', /* bubbles */ false, /* cancelable */ false, detail);

--- a/public/sw.js
+++ b/public/sw.js
@@ -11,7 +11,7 @@ toolbox.options.debug = false;
 
 importScripts('/js/sw-assets-precache.js'); /* global ASSETS */
 
-const VERSION = '8';
+const VERSION = '9';
 const PREFIX = 'gulliver';
 const CACHE_NAME = `${PREFIX}-v${VERSION}`;
 const PWA_OPTION = {


### PR DESCRIPTION
- Once a page is loaded, prefetch the internal links. The
service-worker should cache those, and make them available for
the next request.