### PR TITLE
Fix getSubscription() error

### DIFF
--- a/public/js/messaging.js
+++ b/public/js/messaging.js
@@ -119,17 +119,16 @@ export default class Messaging {
           return Promise.resolve([]);
         }
         const url = TOPICS_ENDPOINT + '?token=' + token;
-        return fetch(url, {
-          headers: {
-            Accept: 'application/json'
-          }
-        });
-      })
-      .then(response => {
-        return response.json();
-      })
-      .then(json => {
-        return json.subscriptions;
+        return fetch(url, {headers: {Accept: 'application/json'}})
+          .then(response => {
+            if (response.status !== 200) {
+              return [];
+            }
+            return response.json()
+              .then(json => {
+                return json.subscriptions;
+              });
+          });
       })
       .catch(err => {
         console.error('Error fetching subscriptions: ', err);


### PR DESCRIPTION
When calling getSubscription, if a token wasn't available, the first Promise would return [], which would then be passed to the next Promise that would try to call .json(). This happens because the Promise was structured the wrong way. 

Fixes #441 