### PR TITLE
URL param in quotes

### DIFF
--- a/lighthouse_machine/server.js
+++ b/lighthouse_machine/server.js
@@ -69,7 +69,7 @@ app.get('/', (req, res) => {
     try {
       exec(
         `node lighthouse-cli --port 9222 --output-path=../report.${req.query.format}\
-        --output=${req.query.format} ${req.query.url}`,
+        --output=${req.query.format} '${req.query.url}'`,
         {
           cwd: '/lighthouse',
           timeout: 500000


### PR DESCRIPTION
Fixes an issue where URLs with GET params get partially trimmed by bash.

For example, `https://www.google.com/search?q=google&oq=google` is passed to Lighthouse as `https://www.google.com/search?q=google` with everything following the ampersand ignored.

With the quote marks, the string is now left alone.
