### PR TITLE
Fixes UnhandledPromiseRejectionWarning

### DIFF
--- a/lib/data-cache.js
+++ b/lib/data-cache.js
@@ -158,6 +158,9 @@ function flushCacheUrls() {
         this.del(url);
       });
       this.del(PAGELIST_URLS);
+    })
+    .catch(err => {
+      console.error('Error flushing cache URLs: ', err);
     });
 }
 


### PR DESCRIPTION
Fixes UnhandledPromiseRejectionWarning when flushCacheUrls() is
invoked but Memcached server is unreacheable